### PR TITLE
fixup! Settings: Add back increasing ring feature (2/2).

### DIFF
--- a/res/xml/sound_settings.xml
+++ b/res/xml/sound_settings.xml
@@ -99,6 +99,7 @@
     <com.bliss.support.preferences.SystemSettingSwitchPreference
         android:key="increasing_ring"
         android:title="@string/increasing_ring_volume_option_title"
+        android:defaultValue="false"
         android:order="-136"
         settings:controller="com.android.settings.notification.IncreasingRingPreferenceController" />
 


### PR DESCRIPTION
increasing_ring SystemSettingSwitchPreference appears always disabled when accesing sound settings despite its real state.

SystemSettingSwitchPreference doesn't check if defaultValue is null, so we must define defaultValue on preference definition.